### PR TITLE
Attempt to fix issues caused by symbolic linking on Windows

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,6 +15,8 @@
 /* Define bootstrap settings. Environments are a better way to handle
  * config but we need to create them first.
  */
+
+define ('BASEDIR',                rtrim(dirname(__FILE__),'\/'), true);
 define ('APP_DIRECTORY',         'bin/apps/',        true);
 define ('CONFIG_DIRECTORY',      'bin/settings/',    true);
 define ('CONTROLLERS_DIRECTORY', 'bin/controllers/', true);
@@ -29,9 +31,9 @@ define ('SESSION_SAVE_PATH',     'bin/usr/sessions/',true);
  * We can watch errors happening live. Grepping them can also help
  * filtering.
  */
-ini_set("log_errors" , "1");
+ini_set("log_errors" , 1);
 ini_set("error_log" , "logs/error_log.log");
-ini_set("display_errors" , "0");
+ini_set("display_errors" , 0);
 
 /* Include Spitfire core.
  */

--- a/spitfire/SpitFire.php
+++ b/spitfire/SpitFire.php
@@ -36,7 +36,7 @@ class SpitFire extends App
 		if (self::$started) { throw new PrivateException('Spitfire is already running'); }
 		
 		#Set the current working directory
-		$this->cwd = dirname(dirname(__FILE__));
+		$this->cwd = BASEDIR;
 		
 		#Import the exception handler for logging
 		$this->debug = ExceptionHandler::getInstance();

--- a/spitfire/autoload_core_files.php
+++ b/spitfire/autoload_core_files.php
@@ -2,132 +2,130 @@
 
 use spitfire\AutoLoad;
 
-#Set the base directory
-$cur_dir = dirname(__FILE__);
 
 #Define default classes and their locations
-AutoLoad::registerClass('spitfire\environment',  $cur_dir.'/environment.php');
+AutoLoad::registerClass('spitfire\environment',                                 SPITFIRE_BASEDIR.'/environment.php');
 
-AutoLoad::registerClass('spitfire\MVC',                                         $cur_dir.'/mvc/mvc.php');
-AutoLoad::registerClass('Controller',            $cur_dir.'/mvc/controller.php');
-AutoLoad::registerClass('spitfire\View',                                        $cur_dir.'/mvc/view.php');
-AutoLoad::registerClass('_SF_ViewElement',       $cur_dir.'/mvc/view_element.php');
+AutoLoad::registerClass('spitfire\MVC',                                         SPITFIRE_BASEDIR.'/mvc/mvc.php');
+AutoLoad::registerClass('Controller',                                           SPITFIRE_BASEDIR.'/mvc/controller.php');
+AutoLoad::registerClass('spitfire\View',                                        SPITFIRE_BASEDIR.'/mvc/view.php');
+AutoLoad::registerClass('_SF_ViewElement',                                      SPITFIRE_BASEDIR.'/mvc/view_element.php');
 
-AutoLoad::registerClass('Time',                                                 $cur_dir.'/time.php');
-AutoLoad::registerClass('Image',                 $cur_dir.'/image.php');
-AutoLoad::registerClass('browser',               $cur_dir.'/security.php');
+AutoLoad::registerClass('Time',                                                 SPITFIRE_BASEDIR.'/time.php');
+AutoLoad::registerClass('Image',                                                SPITFIRE_BASEDIR.'/image.php');
+AutoLoad::registerClass('browser',                                              SPITFIRE_BASEDIR.'/security.php');
 
 #Database related imports
-AutoLoad::registerClass('spitfire\storage\database\Queriable',         $cur_dir.'/db/queriable.php');
-AutoLoad::registerClass('spitfire\storage\database\DBField',           $cur_dir.'/db/field.php');
-AutoLoad::registerClass('spitfire\storage\database\QueryTable',                 $cur_dir.'/db/querytable.php');
-AutoLoad::registerClass('spitfire\storage\database\QueryField',                 $cur_dir.'/db/queryfield.php');
-AutoLoad::registerClass('spitfire\storage\database\Restriction',       $cur_dir.'/db/restriction.php');
-AutoLoad::registerClass('spitfire\storage\database\CompositeRestriction',       $cur_dir.'/db/restrictionComposite.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\Driver',    $cur_dir.'/db/driver.php');
-AutoLoad::registerClass('spitfire\storage\database\Uplink',                     $cur_dir.'/db/uplink.php');
-AutoLoad::registerClass('spitfire\storage\database\Downlink',                   $cur_dir.'/db/downlink.php');
-AutoLoad::registerClass('spitfire\storage\database\Ancestor',                   $cur_dir.'/db/ancestor.php');
-AutoLoad::registerClass('spitfire\storage\database\QueryJoin',                  $cur_dir.'/db/join.php');
-AutoLoad::registerClass('Pagination',            $cur_dir.'/db/pagination.php');
+AutoLoad::registerClass('spitfire\storage\database\Queriable',                  SPITFIRE_BASEDIR.'/db/queriable.php');
+AutoLoad::registerClass('spitfire\storage\database\DBField',                    SPITFIRE_BASEDIR.'/db/field.php');
+AutoLoad::registerClass('spitfire\storage\database\QueryTable',                 SPITFIRE_BASEDIR.'/db/querytable.php');
+AutoLoad::registerClass('spitfire\storage\database\QueryField',                 SPITFIRE_BASEDIR.'/db/queryfield.php');
+AutoLoad::registerClass('spitfire\storage\database\Restriction',                SPITFIRE_BASEDIR.'/db/restriction.php');
+AutoLoad::registerClass('spitfire\storage\database\CompositeRestriction',       SPITFIRE_BASEDIR.'/db/restrictionComposite.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\Driver',             SPITFIRE_BASEDIR.'/db/driver.php');
+AutoLoad::registerClass('spitfire\storage\database\Uplink',                     SPITFIRE_BASEDIR.'/db/uplink.php');
+AutoLoad::registerClass('spitfire\storage\database\Downlink',                   SPITFIRE_BASEDIR.'/db/downlink.php');
+AutoLoad::registerClass('spitfire\storage\database\Ancestor',                   SPITFIRE_BASEDIR.'/db/ancestor.php');
+AutoLoad::registerClass('spitfire\storage\database\QueryJoin',                  SPITFIRE_BASEDIR.'/db/join.php');
+AutoLoad::registerClass('Pagination',                                           SPITFIRE_BASEDIR.'/db/pagination.php');
 
-AutoLoad::registerClass('Model',                                                $cur_dir.'/db/databaseRecord.php');
+AutoLoad::registerClass('Model',                                                SPITFIRE_BASEDIR.'/db/databaseRecord.php');
 
-AutoLoad::registerClass('Validatable',                                          $cur_dir.'/validatable.php');
-AutoLoad::registerClass('ValidationException',                                  $cur_dir.'/validation/ValidationException.php');
-AutoLoad::registerClass('Schema',                                               $cur_dir.'/model/model.php');
-AutoLoad::registerClass('OTFModel',                                             $cur_dir.'/model/onthefly.php');
-AutoLoad::registerClass('spitfire\model\Field',                                 $cur_dir.'/model/field.php');
-AutoLoad::registerClass('IntegerField',                                         $cur_dir.'/model/fields/integer.php');
-AutoLoad::registerClass('FileField',                                            $cur_dir.'/model/fields/file.php');
-AutoLoad::registerClass('TextField',                                            $cur_dir.'/model/fields/text.php');
-AutoLoad::registerClass('StringField',                                          $cur_dir.'/model/fields/string.php');
-AutoLoad::registerClass('EnumField',                                            $cur_dir.'/model/fields/enum.php');
-AutoLoad::registerClass('BooleanField',                                         $cur_dir.'/model/fields/boolean.php');
-AutoLoad::registerClass('DatetimeField',                                        $cur_dir.'/model/fields/datetime.php');
-AutoLoad::registerClass('ManyToManyField',                                      $cur_dir.'/model/fields/manytomany.php');
-AutoLoad::registerClass('Reference',                                            $cur_dir.'/model/reference.php');
-AutoLoad::registerClass('ChildrenField',                                        $cur_dir.'/model/children.php');
+AutoLoad::registerClass('Validatable',                                          SPITFIRE_BASEDIR.'/validatable.php');
+AutoLoad::registerClass('ValidationException',                                  SPITFIRE_BASEDIR.'/validation/ValidationException.php');
+AutoLoad::registerClass('Schema',                                               SPITFIRE_BASEDIR.'/model/model.php');
+AutoLoad::registerClass('OTFModel',                                             SPITFIRE_BASEDIR.'/model/onthefly.php');
+AutoLoad::registerClass('spitfire\model\Field',                                 SPITFIRE_BASEDIR.'/model/field.php');
+AutoLoad::registerClass('IntegerField',                                         SPITFIRE_BASEDIR.'/model/fields/integer.php');
+AutoLoad::registerClass('FileField',                                            SPITFIRE_BASEDIR.'/model/fields/file.php');
+AutoLoad::registerClass('TextField',                                            SPITFIRE_BASEDIR.'/model/fields/text.php');
+AutoLoad::registerClass('StringField',                                          SPITFIRE_BASEDIR.'/model/fields/string.php');
+AutoLoad::registerClass('EnumField',                                            SPITFIRE_BASEDIR.'/model/fields/enum.php');
+AutoLoad::registerClass('BooleanField',                                         SPITFIRE_BASEDIR.'/model/fields/boolean.php');
+AutoLoad::registerClass('DatetimeField',                                        SPITFIRE_BASEDIR.'/model/fields/datetime.php');
+AutoLoad::registerClass('ManyToManyField',                                      SPITFIRE_BASEDIR.'/model/fields/manytomany.php');
+AutoLoad::registerClass('Reference',                                            SPITFIRE_BASEDIR.'/model/reference.php');
+AutoLoad::registerClass('ChildrenField',                                        SPITFIRE_BASEDIR.'/model/children.php');
 
-AutoLoad::registerClass('spitfire\model\adapters\ManyToManyAdapter',            $cur_dir.'/model/adapters/m2madapter.php');
-AutoLoad::registerClass('spitfire\model\adapters\BridgeAdapter',                $cur_dir.'/model/adapters/bridgeadapter.php');
-AutoLoad::registerClass('spitfire\model\adapters\ChildrenAdapter',              $cur_dir.'/model/adapters/childrenadapter.php');
+AutoLoad::registerClass('spitfire\model\adapters\ManyToManyAdapter',            SPITFIRE_BASEDIR.'/model/adapters/m2madapter.php');
+AutoLoad::registerClass('spitfire\model\adapters\BridgeAdapter',                SPITFIRE_BASEDIR.'/model/adapters/bridgeadapter.php');
+AutoLoad::registerClass('spitfire\model\adapters\ChildrenAdapter',              SPITFIRE_BASEDIR.'/model/adapters/childrenadapter.php');
 
-AutoLoad::registerClass('spitfire\model\defaults\userModel',                    $cur_dir.'/model/defaults/usermodel_default.php');
-
-
-AutoLoad::registerClass('spitfire\storage\database\drivers\stdSQLDriver',       $cur_dir.'/db/drivers/stdSQL.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\stdSQLTable',        $cur_dir.'/db/drivers/stdSQLTable.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDODriver',     $cur_dir.'/db/drivers/mysqlPDO.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOTable',      $cur_dir.'/db/drivers/mysqlPDOTable.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOField',      $cur_dir.'/db/drivers/mysqlPDOField.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQuery',      $cur_dir.'/db/drivers/mysqlPDOQuery.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQueryTable', $cur_dir.'/db/drivers/mysqlPDOQueryTable.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQueryField', $cur_dir.'/db/drivers/mysqlPDOQueryField.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOJoin',       $cur_dir.'/db/drivers/mysqlPDOJoin.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORecord',     $cur_dir.'/db/drivers/mysqlPDORecord.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORestriction',$cur_dir.'/db/drivers/mysqlPDORestriction.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOCompositeRestriction',$cur_dir.'/db/drivers/mysqlPDORestrictionComposite.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORestrictionGroup',$cur_dir.'/db/drivers/mysqlPDORestrictionGroup.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOResultSet',  $cur_dir.'/db/drivers/mysqlPDORes.php');
-AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOSelectStringifier',  $cur_dir.'/db/drivers/mysqlPDOSelectStringifier.php');
-
-AutoLoad::registerClass('spitfire\InputSanitizer',                              $cur_dir.'/security_io_sanitization.php');
-AutoLoad::registerClass('CoffeeBean',            $cur_dir.'/io/beans/coffeebean.php');
-AutoLoad::registerClass('spitfire\io\beans\Field',                              $cur_dir.'/io/beans/field.php');
-AutoLoad::registerClass('spitfire\io\beans\BasicField',                         $cur_dir.'/io/beans/basic_field.php');
-AutoLoad::registerClass('spitfire\io\beans\TextField',                          $cur_dir.'/io/beans/text_field.php');
-AutoLoad::registerClass('spitfire\io\beans\IntegerField',                       $cur_dir.'/io/beans/integer_field.php');
-AutoLoad::registerClass('spitfire\io\beans\LongTextField',                      $cur_dir.'/io/beans/long_text_field.php');
-AutoLoad::registerClass('spitfire\io\beans\EnumField',                          $cur_dir.'/io/beans/enum_field.php');
-AutoLoad::registerClass('spitfire\io\beans\BooleanField',                       $cur_dir.'/io/beans/boolean_field.php');
-AutoLoad::registerClass('spitfire\io\beans\ReferenceField',                     $cur_dir.'/io/beans/reference_field.php');
-AutoLoad::registerClass('spitfire\io\beans\ManyToManyField',                    $cur_dir.'/io/beans/manytomany_field.php');
-AutoLoad::registerClass('spitfire\io\beans\FileField',                          $cur_dir.'/io/beans/file_field.php');
-AutoLoad::registerClass('spitfire\io\beans\DateTimeField',                      $cur_dir.'/io/beans/datetime_field.php');
-AutoLoad::registerClass('spitfire\io\beans\ChildBean',                          $cur_dir.'/io/beans/childbean.php');
-AutoLoad::registerClass('spitfire\io\beans\renderers\Renderer',                 $cur_dir.'/io/beans/renderers/renderer.php');
-AutoLoad::registerClass('spitfire\io\beans\renderers\SimpleBeanRenderer',       $cur_dir.'/io/beans/renderers/simpleBeanRenderer.php');
-AutoLoad::registerClass('spitfire\io\beans\renderers\SimpleFieldRenderer',      $cur_dir.'/io/beans/renderers/simpleFieldRenderer.php');
-AutoLoad::registerClass('_SF_Invoke',            $cur_dir.'/mvc/invoke.php');
+AutoLoad::registerClass('spitfire\model\defaults\userModel',                    SPITFIRE_BASEDIR.'/model/defaults/usermodel_default.php');
 
 
-AutoLoad::registerClass('spitfire\io\html\HTMLElement',                         $cur_dir.'/io/html/element.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLUnclosedElement',                 $cur_dir.'/io/html/unclosed.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLDiv',                             $cur_dir.'/io/html/div.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLSpan',                            $cur_dir.'/io/html/span.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLInput',                           $cur_dir.'/io/html/input.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLTextArea',                        $cur_dir.'/io/html/textarea.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLSelect',                          $cur_dir.'/io/html/select.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLOption',                          $cur_dir.'/io/html/option.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLLabel',                           $cur_dir.'/io/html/label.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLForm',                            $cur_dir.'/io/html/form.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLTable',                           $cur_dir.'/io/html/table.php');
-AutoLoad::registerClass('spitfire\io\html\HTMLTableRow',                        $cur_dir.'/io/html/table_row.php');
-AutoLoad::registerClass('spitfire\io\html\dateTimePicker',                      $cur_dir.'/io/html/date_picker.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\stdSQLDriver',       SPITFIRE_BASEDIR.'/db/drivers/stdSQL.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\stdSQLTable',        SPITFIRE_BASEDIR.'/db/drivers/stdSQLTable.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDODriver',     SPITFIRE_BASEDIR.'/db/drivers/mysqlPDO.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOTable',      SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOTable.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOField',      SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOField.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQuery',      SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOQuery.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQueryTable', SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOQueryTable.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOQueryField', SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOQueryField.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOJoin',       SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOJoin.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORecord',     SPITFIRE_BASEDIR.'/db/drivers/mysqlPDORecord.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORestriction',SPITFIRE_BASEDIR.'/db/drivers/mysqlPDORestriction.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDOCompositeRestriction',SPITFIRE_BASEDIR.'/db/drivers/mysqlPDORestrictionComposite.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\MysqlPDORestrictionGroup',SPITFIRE_BASEDIR.'/db/drivers/mysqlPDORestrictionGroup.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOResultSet',  SPITFIRE_BASEDIR.'/db/drivers/mysqlPDORes.php');
+AutoLoad::registerClass('spitfire\storage\database\drivers\mysqlPDOSelectStringifier',  SPITFIRE_BASEDIR.'/db/drivers/mysqlPDOSelectStringifier.php');
 
-AutoLoad::registerClass('Strings',               $cur_dir.'/Strings.php');
+AutoLoad::registerClass('spitfire\InputSanitizer',                              SPITFIRE_BASEDIR.'/security_io_sanitization.php');
+AutoLoad::registerClass('CoffeeBean',                                           SPITFIRE_BASEDIR.'/io/beans/coffeebean.php');
+AutoLoad::registerClass('spitfire\io\beans\Field',                              SPITFIRE_BASEDIR.'/io/beans/field.php');
+AutoLoad::registerClass('spitfire\io\beans\BasicField',                         SPITFIRE_BASEDIR.'/io/beans/basic_field.php');
+AutoLoad::registerClass('spitfire\io\beans\TextField',                          SPITFIRE_BASEDIR.'/io/beans/text_field.php');
+AutoLoad::registerClass('spitfire\io\beans\IntegerField',                       SPITFIRE_BASEDIR.'/io/beans/integer_field.php');
+AutoLoad::registerClass('spitfire\io\beans\LongTextField',                      SPITFIRE_BASEDIR.'/io/beans/long_text_field.php');
+AutoLoad::registerClass('spitfire\io\beans\EnumField',                          SPITFIRE_BASEDIR.'/io/beans/enum_field.php');
+AutoLoad::registerClass('spitfire\io\beans\BooleanField',                       SPITFIRE_BASEDIR.'/io/beans/boolean_field.php');
+AutoLoad::registerClass('spitfire\io\beans\ReferenceField',                     SPITFIRE_BASEDIR.'/io/beans/reference_field.php');
+AutoLoad::registerClass('spitfire\io\beans\ManyToManyField',                    SPITFIRE_BASEDIR.'/io/beans/manytomany_field.php');
+AutoLoad::registerClass('spitfire\io\beans\FileField',                          SPITFIRE_BASEDIR.'/io/beans/file_field.php');
+AutoLoad::registerClass('spitfire\io\beans\DateTimeField',                      SPITFIRE_BASEDIR.'/io/beans/datetime_field.php');
+AutoLoad::registerClass('spitfire\io\beans\ChildBean',                          SPITFIRE_BASEDIR.'/io/beans/childbean.php');
+AutoLoad::registerClass('spitfire\io\beans\renderers\Renderer',                 SPITFIRE_BASEDIR.'/io/beans/renderers/renderer.php');
+AutoLoad::registerClass('spitfire\io\beans\renderers\SimpleBeanRenderer',       SPITFIRE_BASEDIR.'/io/beans/renderers/simpleBeanRenderer.php');
+AutoLoad::registerClass('spitfire\io\beans\renderers\SimpleFieldRenderer',      SPITFIRE_BASEDIR.'/io/beans/renderers/simpleFieldRenderer.php');
+AutoLoad::registerClass('_SF_Invoke',                                           SPITFIRE_BASEDIR.'/mvc/invoke.php');
 
-AutoLoad::registerClass('Locale',                $cur_dir.'/locale/locale.php');
-AutoLoad::registerClass('spitfire\locale\langInfo',                             $cur_dir.'/locale/lang_info.php');
 
-AutoLoad::registerClass('ComponentManager',                                     $cur_dir.'/components/componentManager.php');
-AutoLoad::registerClass('Component',                                            $cur_dir.'/components/component.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLElement',                         SPITFIRE_BASEDIR.'/io/html/element.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLUnclosedElement',                 SPITFIRE_BASEDIR.'/io/html/unclosed.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLDiv',                             SPITFIRE_BASEDIR.'/io/html/div.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLSpan',                            SPITFIRE_BASEDIR.'/io/html/span.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLInput',                           SPITFIRE_BASEDIR.'/io/html/input.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLTextArea',                        SPITFIRE_BASEDIR.'/io/html/textarea.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLSelect',                          SPITFIRE_BASEDIR.'/io/html/select.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLOption',                          SPITFIRE_BASEDIR.'/io/html/option.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLLabel',                           SPITFIRE_BASEDIR.'/io/html/label.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLForm',                            SPITFIRE_BASEDIR.'/io/html/form.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLTable',                           SPITFIRE_BASEDIR.'/io/html/table.php');
+AutoLoad::registerClass('spitfire\io\html\HTMLTableRow',                        SPITFIRE_BASEDIR.'/io/html/table_row.php');
+AutoLoad::registerClass('spitfire\io\html\dateTimePicker',                      SPITFIRE_BASEDIR.'/io/html/date_picker.php');
 
-AutoLoad::registerClass('spitfire\registry\Registry',                           $cur_dir.'/io/registry/registry.php');
-AutoLoad::registerClass('spitfire\registry\JSRegistry',                         $cur_dir.'/io/registry/jsregistry.php');
-AutoLoad::registerClass('spitfire\registry\CSSRegistry',                        $cur_dir.'/io/registry/cssregistry.php');
+AutoLoad::registerClass('Strings',                                              SPITFIRE_BASEDIR.'/Strings.php');
 
-AutoLoad::registerClass('Pluggable',                                            $cur_dir.'/plugins/pluggable.php');
+AutoLoad::registerClass('Locale',                                               SPITFIRE_BASEDIR.'/locale/locale.php');
+AutoLoad::registerClass('spitfire\locale\langInfo',                             SPITFIRE_BASEDIR.'/locale/lang_info.php');
 
-AutoLoad::registerClass('URL',                                                  $cur_dir.'/url.php');
-AutoLoad::registerClass('absoluteURL',                                          $cur_dir.'/absoluteURL.php');
-AutoLoad::registerClass('spitfire\Context',                                     $cur_dir.'/core/context.php');
-AutoLoad::registerClass('spitfire\path\PathParser',                             $cur_dir.'/core/path/PathParser.php');
-AutoLoad::registerClass('spitfire\path\AppParser',                              $cur_dir.'/core/path/AppParser.php');
-AutoLoad::registerClass('spitfire\path\ControllerParser',                       $cur_dir.'/core/path/ControllerParser.php');
-AutoLoad::registerClass('spitfire\path\ActionParser',                           $cur_dir.'/core/path/ActionParser.php');
-AutoLoad::registerClass('spitfire\path\ObjectParser',                           $cur_dir.'/core/path/ObjectParser.php');
-AutoLoad::registerClass('session',               $cur_dir.'/session.php');
+AutoLoad::registerClass('ComponentManager',                                     SPITFIRE_BASEDIR.'/components/componentManager.php');
+AutoLoad::registerClass('Component',                                            SPITFIRE_BASEDIR.'/components/component.php');
 
-AutoLoad::registerClass('Email',                 $cur_dir.'/mail.php');
+AutoLoad::registerClass('spitfire\registry\Registry',                           SPITFIRE_BASEDIR.'/io/registry/registry.php');
+AutoLoad::registerClass('spitfire\registry\JSRegistry',                         SPITFIRE_BASEDIR.'/io/registry/jsregistry.php');
+AutoLoad::registerClass('spitfire\registry\CSSRegistry',                        SPITFIRE_BASEDIR.'/io/registry/cssregistry.php');
+
+AutoLoad::registerClass('Pluggable',                                            SPITFIRE_BASEDIR.'/plugins/pluggable.php');
+
+AutoLoad::registerClass('URL',                                                  SPITFIRE_BASEDIR.'/url.php');
+AutoLoad::registerClass('absoluteURL',                                          SPITFIRE_BASEDIR.'/absoluteURL.php');
+AutoLoad::registerClass('spitfire\Context',                                     SPITFIRE_BASEDIR.'/core/context.php');
+AutoLoad::registerClass('spitfire\path\PathParser',                             SPITFIRE_BASEDIR.'/core/path/PathParser.php');
+AutoLoad::registerClass('spitfire\path\AppParser',                              SPITFIRE_BASEDIR.'/core/path/AppParser.php');
+AutoLoad::registerClass('spitfire\path\ControllerParser',                       SPITFIRE_BASEDIR.'/core/path/ControllerParser.php');
+AutoLoad::registerClass('spitfire\path\ActionParser',                           SPITFIRE_BASEDIR.'/core/path/ActionParser.php');
+AutoLoad::registerClass('spitfire\path\ObjectParser',                           SPITFIRE_BASEDIR.'/core/path/ObjectParser.php');
+AutoLoad::registerClass('session',                                              SPITFIRE_BASEDIR.'/session.php');
+
+AutoLoad::registerClass('Email',                                                SPITFIRE_BASEDIR.'/mail.php');

--- a/spitfire/bootstrap.php
+++ b/spitfire/bootstrap.php
@@ -24,7 +24,13 @@ use spitfire\autoload\RegisteredClassLocator;
  */
 
 #Start loading the core files.
-set_include_path(get_include_path() . PATH_SEPARATOR . dirname(dirname(__FILE__)));
+if (empty($_SERVER['SCRIPT_FILENAME']))
+	$_SERVER['SCRIPT_FILENAME'] = rtrim(exec("pwd"),'\/');
+if (!defined('BASEDIR'))
+	define ('BASEDIR', rtrim(dirname($_SERVER['SCRIPT_FILENAME']),'\/'), true);
+if (!defined('SPITFIRE_BASEDIR'))
+	define ('SPITFIRE_BASEDIR', BASEDIR);
+set_include_path(get_include_path() . PATH_SEPARATOR . BASEDIR);
 require_once 'spitfire/Strings.php';
 require_once 'spitfire/core/functions.php';
 require_once 'spitfire/ClassInfo.php';  //TODO: Remove - Deprecated
@@ -35,21 +41,20 @@ require_once 'spitfire/autoload/namespacedclasslocator.php';
 #Create the autoload. Once started it will allow you to register classes and 
 #locators to retrieve new classes that are missing to your class-space
 $autoload = new spitfire\AutoLoad();
-$basedir  = dirname(dirname(__FILE__));
 
 #These are basic locators that allow spitfire to find it's own classes. Which it's 
 #gonna need to then make the user space classes work
-$autoload->registerLocator(new NamespacedClassLocator('spitfire', $basedir . '/spitfire'));
-$autoload->registerLocator(new RegisteredClassLocator($basedir));
-$autoload->registerLocator(new spitfire\autoload\AppClassLocator($basedir));
+$autoload->registerLocator(new NamespacedClassLocator('spitfire', SPITFIRE_BASEDIR));
+$autoload->registerLocator(new RegisteredClassLocator(BASEDIR));
+$autoload->registerLocator(new spitfire\autoload\AppClassLocator(BASEDIR));
 
 #Register the loaders for the classes within user space
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/controllers', 'Controller'));
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/models',      'Model'));
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/locales',     'Locale'));
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/views',       'View'));
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/beans',       'Bean'));
-$autoload->registerLocator(new NamespacedClassLocator('', $basedir . '/bin/classes'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/controllers', 'Controller'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/models',      'Model'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/locales',     'Locale'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/views',       'View'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/beans',       'Bean'));
+$autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/classes'));
 
 #Import the locations of the most critical components to Spitfire so it has no
 #need to look for them.

--- a/spitfire/bootstrap.php
+++ b/spitfire/bootstrap.php
@@ -23,20 +23,21 @@ use spitfire\autoload\RegisteredClassLocator;
  * and answer accordingly.
  */
 
+/*
+ * If the locations of the spitfire and base directory are not defined we define
+ * them here. This should ensure that the aplication continues to work properly
+ * during testing and under windows environments that do not have proper linking
+ */
+if (!defined('SPITFIRE_BASEDIR')) { define('SPITFIRE_BASEDIR', rtrim(dirname(__FILE__)), '\/'); }
+if (!defined('BASEDIR')         ) { define('BASEDIR', rtrim(dirname(dirname(__FILE__))), '\/'); }
+
 #Start loading the core files.
-if (empty($_SERVER['SCRIPT_FILENAME']))
-	$_SERVER['SCRIPT_FILENAME'] = rtrim(exec("pwd"),'\/');
-if (!defined('BASEDIR'))
-	define ('BASEDIR', rtrim(dirname($_SERVER['SCRIPT_FILENAME']),'\/'), true);
-if (!defined('SPITFIRE_BASEDIR'))
-	define ('SPITFIRE_BASEDIR', BASEDIR);
-set_include_path(get_include_path() . PATH_SEPARATOR . BASEDIR);
-require_once 'spitfire/Strings.php';
-require_once 'spitfire/core/functions.php';
-require_once 'spitfire/ClassInfo.php';  //TODO: Remove - Deprecated
-require_once 'spitfire/autoload.php';
-require_once 'spitfire/autoload/classlocator.php';
-require_once 'spitfire/autoload/namespacedclasslocator.php';
+require_once SPITFIRE_BASEDIR . '/Strings.php';
+require_once SPITFIRE_BASEDIR . '/core/functions.php';
+require_once SPITFIRE_BASEDIR . '/ClassInfo.php';  //TODO: Remove - Deprecated
+require_once SPITFIRE_BASEDIR . '/autoload.php';
+require_once SPITFIRE_BASEDIR . '/autoload/classlocator.php';
+require_once SPITFIRE_BASEDIR . '/autoload/namespacedclasslocator.php';
 
 #Create the autoload. Once started it will allow you to register classes and 
 #locators to retrieve new classes that are missing to your class-space
@@ -58,7 +59,7 @@ $autoload->registerLocator(new NamespacedClassLocator('', BASEDIR . '/bin/classe
 
 #Import the locations of the most critical components to Spitfire so it has no
 #need to look for them.
-require_once 'spitfire/autoload_core_files.php';
+require_once SPITFIRE_BASEDIR . '/autoload_core_files.php';
 
 #Create the exceptionhandler that will capture errors and try to present useful
 #information to the user.

--- a/spitfire/io/session/FileSessionHandler.php
+++ b/spitfire/io/session/FileSessionHandler.php
@@ -51,7 +51,7 @@ class FileSessionHandler extends SessionHandler
 	}
 	
 	public function write($id, $data) {
-		return !!file_put_contents(sprintf('%s/sess_%s', rtrim($this->directory, '\/'), $id), $data);
+		return file_put_contents(sprintf('%s/sess_%s', rtrim($this->directory, '\/'), $id), $data) !== false;
 	}
 
 }


### PR DESCRIPTION
Currently the environment set in `PHPAuthServer/bin/settings/environments.php` seems to be ignored and an error is thrown which shows the default database credentials being used:

```
#0 Spitfire/spitfire/db/drivers/mysqlPDO.php(52): PDO->__construct('mysql:dbname=da...', 'root', '')
#1 Spitfire/spitfire/db/drivers/mysqlPDO.php(71): spitfire\storage\database\drivers\mysqlPDODriver->connect()
#2 Spitfire/spitfire/db/drivers/mysqlPDO.php(120): spitfire\storage\database\drivers\mysqlPDODriver->getConnection()
#3 Spitfire/spitfire/db/drivers/mysqlPDOQuery.php(94): spitfire\storage\database\drivers\mysqlPDODriver->execute('SELECT count(*)...')
#4 Spitfire/spitfire/storage/database/Query.php(167): spitfire\storage\database\drivers\MysqlPDOQuery->execute(Array)
#5 Spitfire/spitfire/storage/database/Query.php(190): spitfire\storage\database\Query->query(Array, true)
#6 PHPAuthServer/bin/controllers/home.php(13): spitfire\storage\database\Query->count()
#7 [internal function]: HomeController->index()
#8 Spitfire/spitfire/core/Context.php(112): call_user_func_array(Array, Array)
#9 Spitfire/spitfire/SpitFire.php(93): spitfire\core\Context->run()
#10 PHPAuthServer/index.php(45): spitfire\SpitFire->fire()
#11 {main}
```